### PR TITLE
Align tag and package versions + SBOM + 2024 edition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,47 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
+  common:
+    name: Common Steps
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Validate Version
+        if: github.event_name == 'release'
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -n 1 | cut -d '"' -f 2)
+          if [ "${{ github.event.release.tag_name }}" != "$VERSION" ]; then
+            echo "Version in Cargo.toml ($VERSION) does not match tag (${{ github.event.release.tag_name }})"
+            exit 1
+          fi
+
+      - uses: advanced-security/generate-sbom-action@v1
+        id: gensbom
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: ${{ steps.gensbom.outputs.fileName }}
+
+      - name: Upload SBOM Release Asset
+        if: github.event_name == 'release'
+        id: upload-sbom-release-asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ${{ steps.gensbom.outputs.fileName }}#"sbom"
+
   build:
+    needs: common
     name: Build and Release
     timeout-minutes: 10
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "RustyIP"
-version = "0.1.0"
+version = "1.6.0"
 dependencies = [
  "hex",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "RustyIP"
-version = "0.1.0"
-edition = "2021"
+version = "1.6.0"
+edition = "2024"
 
 [dependencies]
 rand = "0.9"


### PR DESCRIPTION
Snap to versions with major, minor, patch
Align build and tag/release version numbering
Generate SBOM
Use 2024 Rust edition for no reason