### PR TITLE
Increase timeout for build and release job to 20 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
   build:
     needs: common
     name: Build and Release
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
Increase the timeout for the build and release job to 20 minutes. The ARM32 build setup requires additional time due to large cross-compilation dependencies being installed through `apt`.

**Details**
During the ARM32 build, several heavy packages such as `libstdc++-arm-none-eabi-newlib` (\~463 MB) are downloaded and installed. This extended setup time often exceeds the previous timeout, causing jobs to be canceled before completion. Extending the timeout ensures the build pipeline can finish reliably.