### PR TITLE
Add .deb package generation for Linux releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,12 @@ jobs:
           # Linux
           - { displayName: 32-bit Linux,
               rustTarget: i686-unknown-linux-gnu,
+              debArch: i386,
               runner: ubuntu-latest }
 
           - { displayName: 64-bit Linux,
               rustTarget: x86_64-unknown-linux-gnu,
+              debArch: amd64,
               runner: ubuntu-latest,
               rustflags: '-C target-cpu=x86-64 -C target-feature=-avx,-avx2,-bmi,-bmi2,-fma' }
 
@@ -105,18 +107,22 @@ jobs:
 
           - { displayName: ARM32 ARMv6 Linux,
               rustTarget: arm-unknown-linux-gnueabi,
+              debArch: armel,
               runner: ubuntu-latest }
 
           - { displayName: ARM32 ARMv7 Linux,
               rustTarget: armv7-unknown-linux-gnueabihf,
+              debArch: armhf,
               runner: ubuntu-latest }
 
           - { displayName: ARM64 Linux,
               rustTarget: aarch64-unknown-linux-gnu,
+              debArch: arm64,
               runner: ubuntu-latest }
 
           - { displayName: MIPS64 Linux,
               rustTarget: mips64-unknown-linux-gnuabi64,
+              debArch: mips64,
               runner: ubuntu-latest,
               nightly: true }
 
@@ -226,3 +232,30 @@ jobs:
         run: |
           cp ./target/${{ matrix.target.rustTarget }}/release/RustyIP${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }} ./RustyIP-${{ github.ref_name }}-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }} &&
           gh release upload ${{ github.event.release.tag_name }} ./RustyIP-${{ github.ref_name }}-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }}#"RustyIP-${{ github.ref_name }}-${{ matrix.target.rustTarget }}${{ endsWith(matrix.target.rustTarget, '-windows-gnu') && '.exe' || '' }} (${{ matrix.target.displayName }})"
+
+      - name: Build .deb package
+        if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
+        run: |
+          mkdir -p dpkg/DEBIAN dpkg/usr/local/bin
+          cp ./target/${{ matrix.target.rustTarget }}/release/RustyIP dpkg/usr/local/bin/
+          chmod 755 dpkg/usr/local/bin/RustyIP
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          cat > dpkg/DEBIAN/control << EOF
+          Package: RustyIP
+          Version: $VERSION
+          Architecture: ${{ matrix.target.debArch }}
+          Maintainer: richardsondev
+          Description: IP address lookup tool
+          EOF
+          sed -i 's/^          //' dpkg/DEBIAN/control
+          dpkg-deb --build dpkg RustyIP_${VERSION}_${{ matrix.target.debArch }}.deb
+
+      - name: Upload .deb Release Asset
+        if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          gh release upload ${{ github.event.release.tag_name }} ./RustyIP_${VERSION}_${{ matrix.target.debArch }}.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,9 +236,9 @@ jobs:
       - name: Build .deb package
         if: ${{ github.event_name == 'release' && matrix.target.debArch != '' }}
         run: |
-          mkdir -p dpkg/DEBIAN dpkg/usr/local/bin
-          cp ./target/${{ matrix.target.rustTarget }}/release/RustyIP dpkg/usr/local/bin/
-          chmod 755 dpkg/usr/local/bin/RustyIP
+          mkdir -p dpkg/DEBIAN dpkg/usr/bin
+          cp ./target/${{ matrix.target.rustTarget }}/release/RustyIP dpkg/usr/bin/
+          chmod 755 dpkg/usr/bin/RustyIP
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
           cat > dpkg/DEBIAN/control << EOF
@@ -258,4 +258,4 @@ jobs:
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"
-          gh release upload ${{ github.event.release.tag_name }} ./RustyIP_${VERSION}_${{ matrix.target.debArch }}.deb
+          gh release upload ${{ github.event.release.tag_name }} --clobber ./RustyIP_${VERSION}_${{ matrix.target.debArch }}.deb


### PR DESCRIPTION
## Summary

Adds `.deb` package generation to the release workflow for all Linux architectures.

## Changes

- Added `debArch` field to each Linux target in the build matrix (`i386`, `amd64`, `armel`, `armhf`, `arm64`, `mips64`)
- Added a `Build .deb package` step that uses `dpkg-deb` to create Debian packages after the binary is compiled
- Added `Upload .deb Release Asset` step with `--clobber` for idempotent re-runs
- CPU-variant builds (skylake, znver3) are excluded from `.deb` generation to avoid filename conflicts — only the generic build for each architecture produces a `.deb`
- Binary installs to `/usr/bin/RustyIP`

## How it works

On a `release` event, each Linux matrix job creates a `.deb` package using `dpkg-deb --build`. The package contains the binary at `/usr/bin/RustyIP` and a `DEBIAN/control` file with package name, version (from the release tag), and architecture. The `.deb` is uploaded to the GitHub Release alongside existing raw binaries.

## Architectures

| Debian Arch | Rust Target |
|---|---|
| `amd64` | `x86_64-unknown-linux-gnu` |
| `i386` | `i686-unknown-linux-gnu` |
| `arm64` | `aarch64-unknown-linux-gnu` |
| `armhf` | `armv7-unknown-linux-gnueabihf` |
| `armel` | `arm-unknown-linux-gnueabi` |
| `mips64` | `mips64-unknown-linux-gnuabi64` |

## Usage

```bash
sudo dpkg -i RustyIP_1.06_amd64.deb
RustyIP
```
